### PR TITLE
removing scheme from urls to support loading over https

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
 	<head>
 		<link rel="stylesheet" href="css/beard-simulator.css"/>
 		<link rel="stylesheet" href="css/buttons.css"/>
-		<script src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
+		<script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
 		<script type="text/javascript" src="js/base64binary.min.js"></script>
 		<script type="text/javascript" src="js/facebook-canvas-post.js"></script>
-		<script type="text/javascript" src="http://leemachin.github.io/say-cheese/public/js/say-cheese.js"></script>
-		<script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/fabric.js/1.4.0/fabric.min.js"></script>
+		<script type="text/javascript" src="//leemachin.github.io/say-cheese/public/js/say-cheese.js"></script>
+		<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/fabric.js/1.4.0/fabric.min.js"></script>
 		<script type="text/javascript" src="js/beard-simulator.js"></script>
 		<script>
 			$(function () {


### PR DESCRIPTION
the webcam on chrome wasn't working, checking the console log, I see that it's because it was loaded over http and not https.

The change above will make it load the resources over whatever protocol the page was loaded over.